### PR TITLE
Multi part xml

### DIFF
--- a/src/xml-renderer/index.ts
+++ b/src/xml-renderer/index.ts
@@ -4,6 +4,7 @@ import { renderPitchRhythm } from './pitch-rhythm';
 import { renderListPitch } from './list-pitch';
 import { renderListPitchRhythm } from './list-pitch-rhythm';
 import { renderListListPitch } from './list-list-pitch';
+import { renderListListPitchRhythm } from './list-list-pitch-rhythm';
 import { generateHeader, generateCloser } from './utils';
 
 /**
@@ -37,7 +38,7 @@ export function render(input: RuntimeOutput): string {
         </score-part>
     </part-list>
     <part id="P1">`;
-            output += renderPitchRhythm(input.mainReturn, true);
+            output += renderPitchRhythm(input.mainReturn, true).output;
             output += `
     </part>`;
             output += generateCloser();
@@ -50,6 +51,9 @@ export function render(input: RuntimeOutput): string {
             break;
         case 'list list pitch':
             output += generateHeader() + renderListListPitch(input.mainReturn) + generateCloser();
+            break;
+        case 'list list pitch_rhythm':
+            output += generateHeader() + renderListListPitchRhythm(input.mainReturn) + generateCloser();
             break;
         default:
             console.log(`Type "${mainReturnType}" cannot currently be rendered into XML. Failed to render:

--- a/src/xml-renderer/index.ts
+++ b/src/xml-renderer/index.ts
@@ -3,6 +3,7 @@ import { renderPitch } from './pitch';
 import { renderPitchRhythm } from './pitch-rhythm';
 import { renderListPitch } from './list-pitch';
 import { renderListPitchRhythm } from './list-pitch-rhythm';
+import { renderListListPitch } from './list-list-pitch';
 import { generateHeader, generateCloser } from './utils';
 
 /**
@@ -46,6 +47,9 @@ export function render(input: RuntimeOutput): string {
             break;
         case 'list pitch_rhythm':
             output += generateHeader() + renderListPitchRhythm(input.mainReturn) + generateCloser();
+            break;
+        case 'list list pitch':
+            output += generateHeader() + renderListListPitch(input.mainReturn) + generateCloser();
             break;
         default:
             console.log(`Type "${mainReturnType}" cannot currently be rendered into XML. Failed to render:

--- a/src/xml-renderer/list-list-pitch-rhythm.ts
+++ b/src/xml-renderer/list-list-pitch-rhythm.ts
@@ -1,0 +1,35 @@
+import { RuntimeOutput } from '../runtime';
+import { renderListPitchRhythm } from './list-pitch-rhythm';
+
+// TODO in single list pitch:
+// part name and single part metadata extracted out into a single part name
+
+export function renderListListPitchRhythm(input: RuntimeOutput['mainReturn']): string {
+    // if this list of parts has any global properties,  then we initialize that as the properties in the first measure of all of its child parts
+    if (input.properties) {
+        for (var i = 0; i < input.returnValue.length; i++) {
+            input.returnValue[i].properties = { ...(input.returnValue[i].properties || {}), ...input.properties };
+        }
+    }
+    let listOfPartNames = input.returnValue.map((part: any, idx: number) => part.properties?.part_id || `P${idx + 1}`);
+    let partDeclarations = listOfPartNames
+        .map(
+            (partName: string) =>
+                `      <score-part id="${partName}">
+        <part-name>${partName}</part-name>
+      </score-part>`,
+        )
+        .join('\n');
+    let listPitchHeader = `
+    <part-list>
+${partDeclarations}
+    </part-list>`;
+    let output = listPitchHeader;
+    let count = 0;
+    for (const part of input.returnValue) {
+        output += renderListPitchRhythm(part, listOfPartNames[count]);
+        count++;
+    }
+
+    return output;
+}

--- a/src/xml-renderer/list-list-pitch.ts
+++ b/src/xml-renderer/list-list-pitch.ts
@@ -1,0 +1,35 @@
+import { RuntimeOutput } from '../runtime';
+import { renderListPitch } from './list-pitch';
+
+// TODO in single list pitch:
+// part name and single part metadata extracted out into a single part name
+
+export function renderListListPitch(input: RuntimeOutput['mainReturn']): string {
+    // if this list of parts has any global properties,  then we initialize that as the properties in the first measure of all of its child parts
+    if (input.properties) {
+        for (var i = 0; i < input.returnValue.length; i++) {
+            input.returnValue[i].properties = { ...(input.returnValue[i].properties || {}), ...input.properties };
+        }
+    }
+    let listOfPartNames = input.returnValue.map((part: any, idx: number) => part.properties?.part_id || `P${idx + 1}`);
+    let partDeclarations = listOfPartNames
+        .map(
+            (partName: string) =>
+                `      <score-part id="${partName}">
+        <part-name>${partName}</part-name>
+      </score-part>`,
+        )
+        .join('\n');
+    let listPitchHeader = `
+    <part-list>
+${partDeclarations}
+    </part-list>`;
+    let output = listPitchHeader;
+    let count = 0;
+    for (const part of input.returnValue) {
+        output += renderListPitch(part, listOfPartNames[count]);
+        count++;
+    }
+
+    return output;
+}

--- a/src/xml-renderer/list-pitch-rhythm.ts
+++ b/src/xml-renderer/list-pitch-rhythm.ts
@@ -4,7 +4,7 @@ import { renderPitch } from './pitch';
 export function renderListPitchRhythm(input: RuntimeOutput['mainReturn']): string {
     // first, pass down properties to the first item
     if (input.properties) {
-        input.returnValue[0].properties = { ...input.returnValue[0], ...input.properties };
+        input.returnValue[0].properties = { ...(input.returnValue[0].properties || {}), ...input.properties };
     }
     let id = input.properties?.part_id || 'P1'; // TODO configurability for list list
     let partName = input.properties?.part_name || 'P1';

--- a/src/xml-renderer/list-pitch-rhythm.ts
+++ b/src/xml-renderer/list-pitch-rhythm.ts
@@ -1,27 +1,29 @@
 import { RuntimeOutput } from '../runtime';
-import { renderPitch } from './pitch';
+import { renderPitchRhythm } from './pitch-rhythm';
 
-export function renderListPitchRhythm(input: RuntimeOutput['mainReturn']): string {
+export function renderListPitchRhythm(input: RuntimeOutput['mainReturn'], idOverride?: string): string {
     // first, pass down properties to the first item
     if (input.properties) {
         input.returnValue[0].properties = { ...(input.returnValue[0].properties || {}), ...input.properties };
     }
-    let id = input.properties?.part_id || 'P1'; // TODO configurability for list list
-    let partName = input.properties?.part_name || 'P1';
-    let listPitchHeader = `
+    let id = input.properties?.part_id || idOverride || 'P1';
+    let listPitchHeader = idOverride
+        ? `
+    <part id="${id}">`
+        : `
     <part-list>
         <score-part id="${id}">
-            <part-name>${partName}</part-name>
+            <part-name>${id}</part-name>
         </score-part>
     </part-list>
     <part id="${id}">`;
     let output = listPitchHeader;
-
     let status;
     let count = 0;
     for (const note of input.returnValue) {
-        status = renderPitch(note, count === input.returnValue.length - 1, note.returnValue.rhythm, status);
+        status = renderPitchRhythm(note, count === input.returnValue.length - 1, status);
         output += status.output;
+        count++;
     }
 
     output += `

--- a/src/xml-renderer/list-pitch.ts
+++ b/src/xml-renderer/list-pitch.ts
@@ -4,10 +4,13 @@ import { renderPitch } from './pitch';
 // TODO in single list pitch:
 // part name and single part metadata extracted out into a single part name
 
-export function renderListPitch(input: RuntimeOutput['mainReturn']): string {
-    let id = input.properties?.part_id || 'P1'; // TODO configurability for list list
+export function renderListPitch(input: RuntimeOutput['mainReturn'], idOverride?: string): string {
+    let id = input.properties?.part_id || idOverride || 'P1'; // TODO configurability for list list
     let partName = input.properties?.part_name || 'P1';
-    let listPitchHeader = `
+    let listPitchHeader = idOverride
+        ? `
+    <part id="${id}">`
+        : `
     <part-list>
         <score-part id="${id}">
             <part-name>${partName}</part-name>

--- a/src/xml-renderer/list-pitch.ts
+++ b/src/xml-renderer/list-pitch.ts
@@ -5,6 +5,10 @@ import { renderPitch } from './pitch';
 // part name and single part metadata extracted out into a single part name
 
 export function renderListPitch(input: RuntimeOutput['mainReturn'], idOverride?: string): string {
+    // first, pass down properties to the first item
+    if (input.properties) {
+        input.returnValue[0].properties = { ...(input.returnValue[0].properties || {}), ...input.properties };
+    }
     let id = input.properties?.part_id || idOverride || 'P1'; // TODO configurability for list list
     let partName = input.properties?.part_name || 'P1';
     let listPitchHeader = idOverride

--- a/src/xml-renderer/list-pitch.ts
+++ b/src/xml-renderer/list-pitch.ts
@@ -9,7 +9,7 @@ export function renderListPitch(input: RuntimeOutput['mainReturn'], idOverride?:
     if (input.properties) {
         input.returnValue[0].properties = { ...(input.returnValue[0].properties || {}), ...input.properties };
     }
-    let id = input.properties?.part_id || idOverride || 'P1'; // TODO configurability for list list
+    let id = input.properties?.part_id || idOverride || 'P1';
     let partName = input.properties?.part_name || 'P1';
     let listPitchHeader = idOverride
         ? `

--- a/src/xml-renderer/pitch-rhythm.ts
+++ b/src/xml-renderer/pitch-rhythm.ts
@@ -1,6 +1,10 @@
 import { RuntimeOutput } from '../runtime';
-import { renderPitch } from './pitch';
+import { renderPitch, PitchRenderResult } from './pitch';
 
-export function renderPitchRhythm(input: RuntimeOutput['mainReturn'], isLast: boolean): string {
-    return renderPitch(input, isLast, input.returnValue.rhythm).output;
+export function renderPitchRhythm(
+    input: RuntimeOutput['mainReturn'],
+    isLast: boolean,
+    status?: PitchRenderResult,
+): PitchRenderResult {
+    return renderPitch(input, isLast, input.returnValue.rhythm, status);
 }

--- a/src/xml-renderer/pitch.ts
+++ b/src/xml-renderer/pitch.ts
@@ -3,7 +3,7 @@ import { calculateDuration } from './utils';
 import { LiteralRhythm } from '../lexer/expression/literal';
 
 const divisions = 144;
-interface PitchRenderResult {
+export interface PitchRenderResult {
     output: string;
     timeNumerator: number;
     timeDenominator: number;
@@ -159,8 +159,12 @@ export function renderPitch(
             prerender.attributes.clef
                 ? `<clef>
             <sign>${prerender.attributes.clef.sign}</sign>
-            <line>${prerender.attributes.clef.line}</line>
-            <octave>${prerender.attributes.clef.octave}</octave>
+            <line>${prerender.attributes.clef.line}</line>${
+                      prerender.attributes.clef.octave
+                          ? `
+            <octave>${prerender.attributes.clef.octave}</octave>`
+                          : ''
+                  }
         </clef>`
                 : ''
         }

--- a/tests/xml-renderer/list-list-note.test.ts
+++ b/tests/xml-renderer/list-list-note.test.ts
@@ -355,4 +355,191 @@ fn main(): list list pitch {
     </part>
 </score-partwise>`);
     });
+it('List list pitch: sample program #1', () => {
+        let program = `fn main(): list list pitch_rhythm {
+  list list pitch_rhythm x = [
+          [c#4 quarter,  c#4 quarter,  d4 quarter,  e4 quarter],
+          [a4 quarter,  b4 quarter,  c4 quarter,  d4 quarter ],
+          [c#3 quarter, d3 half]
+         ];
+  x[0].part_id = part one;
+  x[1].part_id = yes this is a part id;
+  x[1][0] = g4 quarter;
+  x[2].clef = bass;
+  x.key = E major;
+  return x;
+}
+`;
+        let stepsResult = makeSyntaxTree(tokenize(program));
+        if (isLeft(stepsResult)) {
+            console.log(`Parse error at line ${stepsResult.left.line}, column ${stepsResult.left.column}`);
+            expect(true).toBe(false);
+            return;
+        }
+        let runtimeResult = runtime(stepsResult.right);
+        if (isLeft(runtimeResult)) {
+            console.log(`Runtime error: ${runtimeResult.left.reason}`);
+            expect(true).toBe(false);
+            return;
+        }
+
+        let renderedXml = render(runtimeResult.right);
+        expect(renderedXml).toBe(`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+    "-//Recordare//DTD MusicXML 3.0 Partwise//EN"
+    "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+    <part-list>
+      <score-part id="part one">
+        <part-name>part one</part-name>
+      </score-part>
+      <score-part id="yes this is a part id">
+        <part-name>yes this is a part id</part-name>
+      </score-part>
+      <score-part id="P3">
+        <part-name>P3</part-name>
+      </score-part>
+    </part-list>
+    <part id="part one">
+        <measure number="1">
+            <attributes>
+                <divisions>144</divisions>
+                <key>
+                    <fifths>4</fifths>
+                    <mode>major</mode>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                </clef>
+            </attributes>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                    <alter>1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                    <alter>1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>d</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>e</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+        </measure>
+    </part>
+    <part id="yes this is a part id">
+        <measure number="1">
+            <attributes>
+                <divisions>144</divisions>
+                <key>
+                    <fifths>4</fifths>
+                    <mode>major</mode>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                </clef>
+            </attributes>
+            <note>
+                <pitch>
+                    <step>g</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>b</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>d</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+        </measure>
+    </part>
+    <part id="P3">
+        <measure number="1">
+            <attributes>
+                <divisions>144</divisions>
+                <key>
+                    <fifths>4</fifths>
+                    <mode>major</mode>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>F</sign>
+                    <line>4</line>
+                </clef>
+            </attributes>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>3</octave>
+                    <alter>1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>d</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>288</duration>
+                <type>half</type>
+            </note>
+        </measure>
+    </part>
+</score-partwise>`);
+    })
 });

--- a/tests/xml-renderer/list-list-note.test.ts
+++ b/tests/xml-renderer/list-list-note.test.ts
@@ -59,7 +59,6 @@ fn main(): list list pitch {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -113,7 +112,6 @@ fn main(): list list pitch {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -213,7 +211,6 @@ fn main(): list list pitch {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -267,7 +264,6 @@ fn main(): list list pitch {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -319,7 +315,6 @@ fn main(): list list pitch {
                 <clef>
                     <sign>F</sign>
                     <line>4</line>
-                    <octave>undefined</octave>
                 </clef>
             </attributes>
             <note>

--- a/tests/xml-renderer/list-list-note.test.ts
+++ b/tests/xml-renderer/list-list-note.test.ts
@@ -1,0 +1,156 @@
+import { render } from '../../src/xml-renderer';
+import { runtime } from '../../src/runtime';
+import { tokenize } from '../../src/lexer/tokenizer';
+import { makeSyntaxTree } from '../../src/lexer/parser';
+import { isLeft } from 'fp-ts/lib/Either';
+
+describe('2d list note renderer tests', () => {
+    it('List list pitch: sample program #1', () => {
+        let program = `
+fn main(): list list pitch {
+  list list pitch x = [
+          [c#4 , c#4 , d4 , e4 ],
+          [a4 , b4 , c4 , d4 ]
+         ];
+
+  x[0].part_id = part one;
+  return x;
+}`;
+        let stepsResult = makeSyntaxTree(tokenize(program));
+        if (isLeft(stepsResult)) {
+            console.log(`Parse error at line ${stepsResult.left.line}, column ${stepsResult.left.column}`);
+            expect(true).toBe(false);
+            return;
+        }
+        let runtimeResult = runtime(stepsResult.right);
+        if (isLeft(runtimeResult)) {
+            console.log(`Runtime error: ${runtimeResult.left.reason}`);
+            expect(true).toBe(false);
+            return;
+        }
+
+        let renderedXml = render(runtimeResult.right);
+        expect(renderedXml).toBe(
+            `<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+    "-//Recordare//DTD MusicXML 3.0 Partwise//EN"
+    "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+    <part-list>
+      <score-part id="part one">
+        <part-name>part one</part-name>
+      </score-part>
+      <score-part id="P2">
+        <part-name>P2</part-name>
+      </score-part>
+    </part-list>
+    <part id="part one">
+        <measure number="1">
+            <attributes>
+                <divisions>144</divisions>
+                <key>
+                    <fifths>0</fifths>
+                    <mode>major</mode>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                    <octave>0</octave>
+                </clef>
+            </attributes>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                    <alter>1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                    <alter>1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>d</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>e</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+        </measure>
+    </part>
+    <part id="P2">
+        <measure number="1">
+            <attributes>
+                <divisions>144</divisions>
+                <key>
+                    <fifths>0</fifths>
+                    <mode>major</mode>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                    <octave>0</octave>
+                </clef>
+            </attributes>
+            <note>
+                <pitch>
+                    <step>a</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>b</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>d</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+        </measure>
+    </part>
+</score-partwise>`,
+        );
+    });
+});

--- a/tests/xml-renderer/list-list-note.test.ts
+++ b/tests/xml-renderer/list-list-note.test.ts
@@ -153,4 +153,211 @@ fn main(): list list pitch {
 </score-partwise>`,
         );
     });
+
+    it('List list pitch: sample program #1', () => {
+        let program = `fn main(): list list pitch {
+  list list pitch x = [
+          [c#4 , c#4 , d4 , e4 ],
+          [a4 , b4 , c4 , d4 ],
+          [c#3, d3, a7, Fb3]
+         ];
+  x[0].part_id = part one;
+  x[1].part_id = yes this is a part id;
+  x[1][0] = g4;
+  x[2].clef = bass;
+  x.key = E major;
+  return x;
+}`;
+        let stepsResult = makeSyntaxTree(tokenize(program));
+        if (isLeft(stepsResult)) {
+            console.log(`Parse error at line ${stepsResult.left.line}, column ${stepsResult.left.column}`);
+            expect(true).toBe(false);
+            return;
+        }
+        let runtimeResult = runtime(stepsResult.right);
+        if (isLeft(runtimeResult)) {
+            console.log(`Runtime error: ${runtimeResult.left.reason}`);
+            expect(true).toBe(false);
+            return;
+        }
+
+        let renderedXml = render(runtimeResult.right);
+        expect(renderedXml).toBe(`<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE score-partwise PUBLIC
+    "-//Recordare//DTD MusicXML 3.0 Partwise//EN"
+    "http://www.musicxml.org/dtds/partwise.dtd">
+<score-partwise version="3.0">
+    <part-list>
+      <score-part id="part one">
+        <part-name>part one</part-name>
+      </score-part>
+      <score-part id="yes this is a part id">
+        <part-name>yes this is a part id</part-name>
+      </score-part>
+      <score-part id="P3">
+        <part-name>P3</part-name>
+      </score-part>
+    </part-list>
+    <part id="part one">
+        <measure number="1">
+            <attributes>
+                <divisions>144</divisions>
+                <key>
+                    <fifths>4</fifths>
+                    <mode>major</mode>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                    <octave>0</octave>
+                </clef>
+            </attributes>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                    <alter>1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                    <alter>1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>d</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>e</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+        </measure>
+    </part>
+    <part id="yes this is a part id">
+        <measure number="1">
+            <attributes>
+                <divisions>144</divisions>
+                <key>
+                    <fifths>4</fifths>
+                    <mode>major</mode>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>G</sign>
+                    <line>2</line>
+                    <octave>0</octave>
+                </clef>
+            </attributes>
+            <note>
+                <pitch>
+                    <step>g</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>b</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>d</step>
+                    <octave>4</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+        </measure>
+    </part>
+    <part id="P3">
+        <measure number="1">
+            <attributes>
+                <divisions>144</divisions>
+                <key>
+                    <fifths>4</fifths>
+                    <mode>major</mode>
+                </key>
+                <time>
+                    <beats>4</beats>
+                    <beat-type>4</beat-type>
+                </time>
+                <clef>
+                    <sign>F</sign>
+                    <line>4</line>
+                    <octave>undefined</octave>
+                </clef>
+            </attributes>
+            <note>
+                <pitch>
+                    <step>c</step>
+                    <octave>3</octave>
+                    <alter>1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>d</step>
+                    <octave>3</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>a</step>
+                    <octave>7</octave>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+            <note>
+                <pitch>
+                    <step>f</step>
+                    <octave>3</octave>
+                    <alter>-1</alter>
+                </pitch>
+                <duration>144</duration>
+                <type>quarter</type>
+            </note>
+        </measure>
+    </part>
+</score-partwise>`);
+    });
 });

--- a/tests/xml-renderer/list-note.test.ts
+++ b/tests/xml-renderer/list-note.test.ts
@@ -47,7 +47,6 @@ describe('list of notes XML renderer tests', () => {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -131,7 +130,6 @@ describe('list of notes XML renderer tests', () => {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>

--- a/tests/xml-renderer/single-note.test.ts
+++ b/tests/xml-renderer/single-note.test.ts
@@ -47,7 +47,6 @@ describe('single note XML renderer tests', () => {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -105,7 +104,6 @@ describe('single note XML renderer tests', () => {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -164,7 +162,6 @@ describe('single note XML renderer tests', () => {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -224,7 +221,6 @@ describe('single note XML renderer tests', () => {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>
@@ -284,7 +280,6 @@ describe('single note XML renderer tests', () => {
                 <clef>
                     <sign>G</sign>
                     <line>2</line>
-                    <octave>0</octave>
                 </clef>
             </attributes>
             <note>


### PR DESCRIPTION
Support rendering 2d lists into musicXML:
* add tests for 2d lists of pitches and pitch_rhythms 
* allow clefs and keys to be initialized by the 2d list itself and they pass down to child lists


Example:
```
fn main(): list list pitch_rhythm {
    list list pitch_rhythm my_song = [
      [d4 quarter, d4 quarter, a4 quarter, a4 quarter],
      [d3 half,                a3 half]
    ];
    my_song[1].clef = bass;
    my_song[0].part_id = melody;
    my_song.key = d major;

   return my_song;
}
```

produces the output:

![sky output](https://songq.in/images/misc/PR_image_sky.png)